### PR TITLE
Removed redundant batch_size param

### DIFF
--- a/src/DataHandler/dataLoader.zig
+++ b/src/DataHandler/dataLoader.zig
@@ -73,9 +73,9 @@ pub fn DataLoader(comptime OutType: type, comptime Ftype: type, comptime LabelTy
         }
         //Maybe do batch size as a "attribute of the struct"
         ///Get the next batch of data
-        pub fn xNextBatch(self: *@This(), batch_size: usize) ?[][]OutType {
+        pub fn xNextBatch(self: *@This()) ?[][]OutType {
             const start = self.x_index;
-            const end = @min(start + batch_size, self.X.len);
+            const end = @min(start + self.batchSize, self.X.len);
 
             if (start >= end) return null;
 
@@ -85,9 +85,9 @@ pub fn DataLoader(comptime OutType: type, comptime Ftype: type, comptime LabelTy
             return batch;
         }
         ///Y next label iterator like in batch
-        pub fn yNextBatch(self: *@This(), batch_size: usize) ?[]OutType {
+        pub fn yNextBatch(self: *@This()) ?[]OutType {
             const start = self.y_index;
-            const end = @min(start + batch_size, self.y.len);
+            const end = @min(start + self.batchSize, self.y.len);
 
             if (start >= end) return null;
 
@@ -160,12 +160,12 @@ pub fn DataLoader(comptime OutType: type, comptime Ftype: type, comptime LabelTy
             }
         }
 
-        pub fn xTrainNextBatch(self: *@This(), batch_size: usize) ?MagicalReturnType(OutType, dimInput) {
+        pub fn xTrainNextBatch(self: *@This()) ?MagicalReturnType(OutType, dimInput) {
             if (self.X_train == null) return null;
             const x_train = self.X_train.?;
 
             const start = self.x_train_index;
-            const end = @min(start + batch_size, x_train.len);
+            const end = @min(start + self.batchSize, x_train.len);
 
             if (start >= end) return null;
 
@@ -175,12 +175,12 @@ pub fn DataLoader(comptime OutType: type, comptime Ftype: type, comptime LabelTy
             return batch;
         }
 
-        pub fn yTrainNextBatch(self: *@This(), batch_size: usize) ?[]OutType {
+        pub fn yTrainNextBatch(self: *@This()) ?[]OutType {
             if (self.y_train == null) return null;
             const y_train = self.y_train.?;
 
             const start = self.y_train_index;
-            const end = @min(start + batch_size, y_train.len);
+            const end = @min(start + self.batchSize, y_train.len);
 
             if (start >= end) return null;
 
@@ -190,12 +190,12 @@ pub fn DataLoader(comptime OutType: type, comptime Ftype: type, comptime LabelTy
             return batch;
         }
 
-        pub fn xTestNextBatch(self: *@This(), batch_size: usize) ?MagicalReturnType(OutType, dimInput) {
+        pub fn xTestNextBatch(self: *@This()) ?MagicalReturnType(OutType, dimInput) {
             if (self.X_test == null) return null;
             const x_test = self.X_test.?;
 
             const start = self.x_test_index;
-            const end = @min(start + batch_size, x_test.len);
+            const end = @min(start + self.batchSize, x_test.len);
 
             if (start >= end) return null;
 
@@ -205,12 +205,12 @@ pub fn DataLoader(comptime OutType: type, comptime Ftype: type, comptime LabelTy
             return batch;
         }
 
-        pub fn yTestNextBatch(self: *@This(), batch_size: usize) ?[]OutType {
+        pub fn yTestNextBatch(self: *@This()) ?[]OutType {
             if (self.y_test == null) return null;
             const y_test = self.y_test.?;
 
             const start = self.y_test_index;
-            const end = @min(start + batch_size, y_test.len);
+            const end = @min(start + self.batchSize, y_test.len);
 
             if (start >= end) return null;
 

--- a/src/DataHandler/trainer.zig
+++ b/src/DataHandler/trainer.zig
@@ -77,8 +77,8 @@ pub fn TrainDataLoader(
         var optimizer = Optim.Optimizer(T, XType, YType, Optim.optimizer_SGD, lr, allocator){};
 
         for (0..steps) |step| {
-            _ = load.xTrainNextBatch(batchSize);
-            _ = load.yTrainNextBatch(batchSize);
+            _ = load.xTrainNextBatch();
+            _ = load.yTrainNextBatch();
             try load.toTensor(allocator, &shapeX, &shapeY);
             try convertToOneHot(T, batchSize, &load.yTensor);
 
@@ -206,8 +206,8 @@ pub fn TrainDataLoader2D(
         var totalSamplesVal: u16 = 0;
 
         for (0..steps) |step| {
-            _ = load.xTrainNextBatch(batchSize);
-            _ = load.yTrainNextBatch(batchSize);
+            _ = load.xTrainNextBatch();
+            _ = load.yTrainNextBatch();
             try load.toTensor(allocator, &shapeX, &shapeY);
 
             try convertToOneHot(T, batchSize, &load.yTensor);
@@ -256,8 +256,8 @@ pub fn TrainDataLoader2D(
         std.debug.print("\nNumber of validation steps: {}\n", .{val_steps});
 
         for (0..val_steps) |step| {
-            _ = load.xTestNextBatch(batchSize);
-            _ = load.yTestNextBatch(batchSize);
+            _ = load.xTestNextBatch();
+            _ = load.yTestNextBatch();
             try load.toTensor(allocator, &shapeX, &shapeY);
             try convertToOneHot(T, batchSize, &load.yTensor);
             //try DataProc.normalize(T, &load.xTensor, NormalizType.StandardDeviationNormalization);

--- a/src/tests/tests_dataLoader.zig
+++ b/src/tests/tests_dataLoader.zig
@@ -379,10 +379,6 @@ test "To Tensor Batch Test" {
     featureSlices[1] = &features[1];
     const labelSlice: []f64 = &labelSlices;
 
-    var shapeXArr = [_]usize{ 1, 3 };
-    var shapeYArr = [_]usize{1};
-    var shapeX: []usize = &shapeXArr;
-    var shapeY: []usize = &shapeYArr;
     var loader = DataLoader(f64, f64, u8, 1, 2){
         .X = &featureSlices,
         .y = labelSlice,
@@ -391,9 +387,13 @@ test "To Tensor Batch Test" {
         .XBatch = undefined,
         .yBatch = undefined,
     };
+    var shapeXArr = [_]usize{ loader.batchSize, 3 };
+    var shapeYArr = [_]usize{loader.batchSize};
+    var shapeX: []usize = &shapeXArr;
+    var shapeY: []usize = &shapeYArr;
 
-    _ = loader.xNextBatch(1);
-    _ = loader.yNextBatch(1);
+    _ = loader.xNextBatch();
+    _ = loader.yNextBatch();
     try loader.toTensor(&allocator, &shapeX, &shapeY);
     try std.testing.expect(loader.xTensor.shape[0] == 1);
     try std.testing.expect(loader.xTensor.shape[1] == 3);
@@ -405,7 +405,7 @@ test "To Tensor Batch Test" {
 
 test "MNIST batch and to Tensor test" {
     var allocator = pkgAllocator.allocator;
-    var loader = DataLoader(f64, f64, f64, 1, 2){
+    var loader = DataLoader(f64, f64, f64, 2, 2){
         .X = undefined,
         .y = undefined,
         .xTensor = undefined,
@@ -422,12 +422,12 @@ test "MNIST batch and to Tensor test" {
 
     try std.testing.expectEqual(loader.X.len, 10000);
     try std.testing.expectEqual(loader.y.len, 10000);
-    var shapeXArr = [_]usize{ 2, 784 };
-    var shapeYArr = [_]usize{2};
+    var shapeXArr = [_]usize{ loader.batchSize, 784 };
+    var shapeYArr = [_]usize{loader.batchSize};
     var shapeX: []usize = &shapeXArr;
     var shapeY: []usize = &shapeYArr;
-    _ = loader.xNextBatch(2);
-    _ = loader.yNextBatch(2);
+    _ = loader.xNextBatch();
+    _ = loader.yNextBatch();
     try loader.toTensor(&allocator, &shapeX, &shapeY);
     try std.testing.expect(loader.xTensor.shape[0] == 2);
     try std.testing.expect(loader.xTensor.shape[1] == 784);
@@ -438,7 +438,7 @@ test "MNIST batch and to Tensor test" {
 }
 test "Shuffling and data split" {
     var allocator = pkgAllocator.allocator;
-    var loader = DataLoader(f64, f64, f64, 1, 2){
+    var loader = DataLoader(f64, f64, f64, 32, 2){
         .X = undefined,
         .y = undefined,
         .xTensor = undefined,
@@ -450,8 +450,8 @@ test "Shuffling and data split" {
 
     const image_file_name: []const u8 = "datasets/t10k-images-idx3-ubyte";
     const label_file_name: []const u8 = "datasets/t10k-labels-idx1-ubyte";
-    var shapeXArr = [_]usize{ 32, 784 };
-    var shapeYArr = [_]usize{32};
+    var shapeXArr = [_]usize{ loader.batchSize, 784 };
+    var shapeYArr = [_]usize{loader.batchSize};
     var shapeX: []usize = &shapeXArr;
     var shapeY: []usize = &shapeYArr;
 
@@ -461,10 +461,10 @@ test "Shuffling and data split" {
     const train_samples = loader.X_train.?.len;
     const test_samples = loader.X_test.?.len;
     try std.testing.expect(test_samples == total_samples - train_samples);
-    const x_batch = loader.xTrainNextBatch(32) orelse unreachable;
-    const y_batch = loader.yTrainNextBatch(32) orelse unreachable;
-    const x_testBatch = loader.xTestNextBatch(32) orelse unreachable;
-    const y_testBatch = loader.yTestNextBatch(32) orelse unreachable;
+    const x_batch = loader.xTrainNextBatch() orelse unreachable;
+    const y_batch = loader.yTrainNextBatch() orelse unreachable;
+    const x_testBatch = loader.xTestNextBatch() orelse unreachable;
+    const y_testBatch = loader.yTestNextBatch() orelse unreachable;
 
     try std.testing.expect(x_batch.len == 32);
     try std.testing.expect(y_batch.len == 32);
@@ -493,8 +493,8 @@ test "Shuffling and data split 2D" {
     const image_file_name: []const u8 = "datasets/t10k-images-idx3-ubyte";
     const label_file_name: []const u8 = "datasets/t10k-labels-idx1-ubyte";
 
-    var shapeXArr = [_]usize{ 32, 28, 28 };
-    var shapeYArr = [_]usize{32};
+    var shapeXArr = [_]usize{ loader.batchSize, 28, 28 };
+    var shapeYArr = [_]usize{loader.batchSize};
     var shapeX: []usize = &shapeXArr;
     var shapeY: []usize = &shapeYArr;
 
@@ -507,10 +507,10 @@ test "Shuffling and data split 2D" {
 
     try std.testing.expect(test_samples == total_samples - train_samples);
 
-    const x_batch = loader.xTrainNextBatch(32) orelse unreachable;
-    const y_batch = loader.yTrainNextBatch(32) orelse unreachable;
-    const x_testBatch = loader.xTestNextBatch(32) orelse unreachable;
-    const y_testBatch = loader.yTestNextBatch(32) orelse unreachable;
+    const x_batch = loader.xTrainNextBatch() orelse unreachable;
+    const y_batch = loader.yTrainNextBatch() orelse unreachable;
+    const x_testBatch = loader.xTestNextBatch() orelse unreachable;
+    const y_testBatch = loader.yTestNextBatch() orelse unreachable;
 
     try std.testing.expect(x_batch.len == 32);
     try std.testing.expect(y_batch.len == 32);


### PR DESCRIPTION

## Description

"batch_size" redundant parameter has been removed from all dataloader functions as it was already present in its struct and corresponding tests have been also modified accordingly.

**Related Issue:** Closes #54

## Type of Change

Please mark the options that are relevant:

- [X] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Documentation update 📚
- [ ] Other (please describe):

## Checklist

- [X] My code follows the project's coding style guidelines.
- [X] I have performed a self-review of my own code.
- [X] I have made corresponding updates to the documentation.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] All new and existing tests pass.

## Testing

Usual `zig build test_all --summary all`
