### PR TITLE
gemm, dot_product, transposeLastTwo

### DIFF
--- a/src/Core/Tensor/TensorMath/op_gemm.zig
+++ b/src/Core/Tensor/TensorMath/op_gemm.zig
@@ -1,0 +1,222 @@
+const std = @import("std");
+const Tensor = @import("tensor").Tensor;
+const TensorError = @import("errorHandler").TensorError;
+const TensorMathError = @import("errorHandler").TensorMathError;
+const pkg_allocator = @import("pkgAllocator").allocator;
+const TensMath = @import("tensor_math_standard.zig");
+const LeanTensMath = @import("tensor_math_lean.zig");
+
+// Note that this functions needs SIMD optimizations
+
+/// Implements the GEMM operator from the ONNX standard https://onnx.ai/onnx/operators/onnx__Gemm.html Y = alpha*A*B + beta*C
+/// As for now the broadcasting only accours in rows and cols dimensions, while batch and channel dimensions must have the same size
+pub fn gemm(comptime T: anytype, A: *Tensor(T), B: *Tensor(T), C: ?*Tensor(T), alpha: f32, beta: f32, transA: bool, transB: bool) !Tensor(T) {
+    var cond_A: usize = 0;
+    var cond_B: usize = 0;
+    var res_rows: usize = 0;
+    var res_cols: usize = 0;
+
+    // verifying correct shape, batch, channels
+    if (A.shape.len != 4 or B.shape.len != 4) {
+        return TensorMathError.InputTensorsWrongShape;
+    }
+    if (A.shape[0] != B.shape[0] or A.shape[1] != B.shape[1]) {
+        return TensorMathError.InputTensorDifferentShape;
+    }
+
+    // verifying matrix multiplication viability, getting result shape
+    if (transA) {
+        cond_A = A.shape[2];
+        res_rows = A.shape[3];
+    } else {
+        cond_A = A.shape[3];
+        res_rows = A.shape[2];
+    }
+
+    if (transB) {
+        cond_B = B.shape[3];
+        res_cols = B.shape[2];
+    } else {
+        cond_B = B.shape[2];
+        res_cols = B.shape[3];
+    }
+
+    if (cond_A != cond_B) {
+        return TensorMathError.InputTensorDimensionMismatch;
+    }
+
+    // control on optional tensor C unwrapping it
+    if (C) |actual_C| {
+        if (actual_C.shape.len != 4) {
+            return TensorMathError.InputTensorsWrongShape;
+        }
+        if (actual_C.shape[0] != A.shape[0] or actual_C.shape[1] != A.shape[1]) {
+            return TensorMathError.InputTensorDifferentShape;
+        }
+        if ((actual_C.shape[2] != res_rows and actual_C.shape[2] != 1) or (actual_C.shape[3] != res_cols and actual_C.shape[3] != 1)) {
+            return TensorMathError.IncompatibleBroadcastShapes;
+        }
+    }
+
+    // creating result tensor
+    var res_shape = try pkg_allocator.alloc(usize, 4);
+    defer pkg_allocator.free(res_shape);
+    res_shape[0] = A.shape[0];
+    res_shape[1] = A.shape[1];
+    res_shape[2] = res_rows;
+    res_shape[3] = res_cols;
+
+    var result = try Tensor(T).fromShape(&pkg_allocator, res_shape);
+    errdefer result.deinit();
+
+    // debug
+    // for (0..A.data.len) |i|
+    //     std.debug.print("\n gemm A[{d}] {d}", .{ i, A.data[i] });
+    // for (0..B.data.len) |i|
+    //     std.debug.print("\n gemm B[{d}] {d}", .{ i, B.data[i] });
+    // if (C) |CC| {
+    //     for (0..CC.data.len) |i|
+    //         std.debug.print("\n gemm C[{d}] {d}", .{ i, CC.data[i] });
+    // }
+
+    try lean_gemm(T, A, B, C, alpha, beta, transA, transB, &result);
+
+    return result;
+}
+
+/// Lean version of gemm, output Tensor must be preconstructed and 0 filled
+pub fn lean_gemm(comptime T: anytype, A: *Tensor(T), B: *Tensor(T), C: ?*Tensor(T), alpha: f32, beta: f32, transA: bool, transB: bool, result: *Tensor(T)) !void {
+    var actual_A_ptr = A;
+    var actual_B_ptr = B;
+
+    // applying transposition
+    if (transA) {
+        var actual_A = try transposeLastTwo(T, A);
+        actual_A_ptr = &actual_A;
+    }
+    if (transB) {
+        var actual_B = try transposeLastTwo(T, B);
+        actual_B_ptr = &actual_B;
+    }
+
+    // debug
+    // for (0..actual_A_ptr.data.len) |i|
+    //     std.debug.print("\n TRANS LEAN A[{d}] {d}", .{ i, actual_A_ptr.data[i] });
+    // for (0..actual_B_ptr.data.len) |i|
+    //     std.debug.print("\n TRANS LEAN B[{d}] {d}", .{ i, actual_B_ptr.data[i] });
+    // if (C) |CC| {
+    //     for (0..CC.data.len) |i|
+    //         std.debug.print("\n NO TRANS LEAN C[{d}] {d}", .{ i, CC.data[i] });
+    // }
+
+    // result = alpha * A * B
+    try LeanTensMath.lean_dot_product_tensor(T, T, actual_A_ptr, actual_B_ptr, result);
+    for (0..result.size) |i| {
+        result.data[i] *= alpha;
+    }
+
+    // debug
+    // for (0..result.data.len) |i|
+    //     std.debug.print("\n LEAN PRODUCT PR[{d}] {d}", .{ i, result.data[i] });
+
+    // result = result + beta * C
+    if (C) |actual_C_ptr| {
+        if (beta != 0) {
+
+            // no broadcast necessary
+            if (result.size == actual_C_ptr.size) {
+                for (0..result.size) |i| {
+                    result.data[i] += actual_C_ptr.data[i] * beta;
+                }
+            }
+
+            // broadcast from C to result
+            else {
+                const res_rows = result.shape[result.shape.len - 2];
+                const res_cols = result.shape[result.shape.len - 1];
+
+                // Determine whether broadcast on rows and cols is needed or not
+                const c_rows = if (actual_C_ptr.shape.len >= 2) actual_C_ptr.shape[actual_C_ptr.shape.len - 2] else 1;
+                const c_cols = if (actual_C_ptr.shape.len >= 1) actual_C_ptr.shape[actual_C_ptr.shape.len - 1] else 1;
+
+                for (0..actual_A_ptr.shape[0]) |b| {
+                    for (0..actual_A_ptr.shape[1]) |c| {
+                        for (0..res_rows) |i| {
+                            for (0..res_cols) |j| {
+
+                                // index used on C
+                                const ci = if (c_rows == 1) 0 else i;
+                                const cj = if (c_cols == 1) 0 else j;
+
+                                // summing the product of C and beta
+                                const result_index = (((b * result.shape[1]) + c) * result.shape[2] + i) * result.shape[3] + j;
+                                const c_index = (((b * actual_C_ptr.shape[1]) + c) * actual_C_ptr.shape[2] + ci) * actual_C_ptr.shape[3] + cj;
+                                result.data[result_index] += actual_C_ptr.data[c_index] * beta;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // debug
+    // for (0..result.data.len) |i|
+    //     std.debug.print("\n LEAN SUM SM[{d}] {d}", .{ i, result.data[i] });
+
+    if (transA) {
+        actual_A_ptr.deinit();
+    }
+    if (transB) {
+        actual_B_ptr.deinit();
+    }
+}
+
+// TODO: move it in lib_shape_math.zig, add test
+/// Given a 4D tensor it returns the tensor with the last 2 dimensions transposed. Operates on both data and shape, does not modify self, used by gemm.
+pub fn transposeLastTwo(comptime T: anytype, tensor: *const Tensor(T)) !Tensor(T) {
+
+    // Veryfing correct shape
+    if (tensor.shape.len != 4) {
+        return TensorMathError.InputTensorsWrongShape;
+    }
+
+    const batch = tensor.shape[0];
+    const channel = tensor.shape[1];
+    const rows = tensor.shape[2];
+    const cols = tensor.shape[3];
+    const total = batch * channel * rows * cols;
+
+    // New shape
+    const newShape = try pkg_allocator.alloc(usize, 4);
+    errdefer pkg_allocator.free(newShape);
+    newShape[0] = batch;
+    newShape[1] = channel;
+    newShape[2] = cols;
+    newShape[3] = rows;
+
+    // New data
+    const outData = try tensor.allocator.alloc(T, total);
+    errdefer tensor.allocator.free(outData);
+
+    // Traspose the elements within the matrix
+    for (0..batch) |b| {
+        for (0..channel) |c| {
+            for (0..rows) |i| {
+                for (0..cols) |j| {
+                    const index_in = (((b * channel) + c) * rows + i) * cols + j;
+                    const index_out = (((b * channel) + c) * cols + j) * rows + i;
+                    outData[index_out] = tensor.data[index_in];
+                }
+            }
+        }
+    }
+
+    // Build tensor and return
+    return Tensor(T){
+        .data = outData,
+        .size = total,
+        .shape = newShape,
+        .allocator = tensor.allocator,
+    };
+}

--- a/src/Core/Tensor/TensorMath/tensor_math_lean.zig
+++ b/src/Core/Tensor/TensorMath/tensor_math_lean.zig
@@ -5,6 +5,8 @@
 // ---------------------------- importing methods ----------------------------
 // ---------------------------------------------------------------------------
 //
+
+// ---------- importing lean Element-Wise math ----------
 const lean_elementWise_math_lib = @import("lib_elementWise_math.zig");
 //pub const add_bias = lean_elementWise_math_lib.add_bias;
 pub const sum_tensors = lean_elementWise_math_lib.lean_sum_tensors;
@@ -12,13 +14,23 @@ pub const sum_tensors = lean_elementWise_math_lib.lean_sum_tensors;
 pub const mul = lean_elementWise_math_lib.mul_lean;
 pub const div = lean_elementWise_math_lib.div_lean;
 
+// ---------- importing lean Convolution methods ----------
 const lean_op_convolution = @import("op_convolution.zig");
 pub const im2col = lean_op_convolution.lean_im2col;
 
+// ---------- importing lean structural methods ----------
 const shape_math_lib = @import("lib_shape_math.zig");
 pub const get_resize_output_shape = shape_math_lib.get_resize_output_shape;
 pub const get_concatenate_output_shape = shape_math_lib.get_concatenate_output_shape;
 pub const get_split_output_shapes = shape_math_lib.get_split_output_shapes;
+
+// ---------- importing lean matrix algebra methods ----------
+const dot_product = @import("op_dot_product.zig");
+pub const lean_dot_product_tensor = dot_product.lean_dot_product_tensor;
+
+// ---------- importing lean gemm method ----------
+const op_gemm = @import("op_gemm.zig");
+pub const gemm = op_gemm.lean_gemm;
 
 // ---------- importing lean activation function methods ----------
 const activation_math_lib = @import("lib_activation_function_math.zig");
@@ -32,7 +44,6 @@ pub const sigmoid = activation_math_lib.lean_sigmoid;
 pub const softmax = activation_math_lib.lean_softmax;
 
 // ---------- importing lean convolution methods ----------
-
 const op_convolution = @import("op_convolution.zig");
 
 pub const convolve_tensor_with_bias = op_convolution.convolve_tensor_with_bias;

--- a/src/Core/Tensor/TensorMath/tensor_math_standard.zig
+++ b/src/Core/Tensor/TensorMath/tensor_math_standard.zig
@@ -5,7 +5,7 @@
 
 // ---------- importing standard reduction and logical methods ----------
 
-// ---------- importing standard strucutal methods ----------
+// ---------- importing standard structural methods ----------
 const shape_math_lib = @import("lib_shape_math.zig");
 pub const concatenate = shape_math_lib.concatenate;
 pub const get_concatenate_output_shape = shape_math_lib.get_concatenate_output_shape;
@@ -26,6 +26,10 @@ pub const get_split_output_shapes = shape_math_lib.get_split_output_shapes;
 const dot_product = @import("op_dot_product.zig");
 pub const dot_product_tensor = dot_product.dot_product_tensor;
 pub const dot_product_tensor_flat = dot_product.dot_product_tensor_flat;
+
+// ---------- importing standard gemm method ----------
+const op_gemm = @import("op_gemm.zig");
+pub const gemm = op_gemm.gemm;
 
 // ---------- importing standard Convolution methods ----------
 const convolution_math_lib = @import("op_convolution.zig");

--- a/tests/Core/Tensor/TensorMath/test_op_gemm.zig
+++ b/tests/Core/Tensor/TensorMath/test_op_gemm.zig
@@ -1,0 +1,332 @@
+const std = @import("std");
+const pkgAllocator = @import("pkgAllocator");
+const TensMath = @import("tensor_m");
+const Tensor = @import("tensor").Tensor;
+const TensorMathError = @import("errorHandler").TensorMathError;
+const TensorError = @import("errorHandler").TensorError;
+const ErrorHandler = @import("errorHandler");
+
+// TODO: add test for multiple batch/channel
+
+test "Gemm Y = a A*B" {
+    std.debug.print("\n     test: Gemm Y = a A*B", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape: [4]usize = [_]usize{ 1, 1, 2, 2 }; // 1 batch, 1 channel, 2x2 matrix
+
+    var inputArray: [2][2]f32 = [_][2]f32{
+        [_]f32{ 1.0, 2.0 },
+        [_]f32{ 4.0, 5.0 },
+    };
+
+    var t1 = try Tensor(f32).fromArray(&allocator, &inputArray, &shape);
+    var t2 = try Tensor(f32).fromArray(&allocator, &inputArray, &shape);
+
+    var result_tensor = try TensMath.gemm(f32, &t1, &t2, null, 1, 1, false, false);
+
+    try std.testing.expect(9.0 == result_tensor.data[0]);
+    try std.testing.expect(12.0 == result_tensor.data[1]);
+
+    result_tensor.deinit();
+    t1.deinit();
+    t2.deinit();
+}
+
+test "Gemm Y = a A*B + bC without broadcasting" {
+    std.debug.print("\n     test: Gemm Y = a A*B + bC without broadcasting", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var a_shape: [4]usize = [_]usize{ 1, 1, 2, 2 }; // 1 batch, 1 channel, 2x2 matrix
+    var b_shape: [4]usize = [_]usize{ 1, 1, 2, 1 }; // 1 batch, 1 channel, 2x1 matrix
+
+    var inputArrayA: [2][2]f32 = [_][2]f32{
+        [_]f32{ 1.0, 2.0 },
+        [_]f32{ 4.0, 5.0 },
+    };
+    var inputArrayB: [2][1]f32 = [_][1]f32{
+        [_]f32{1.0},
+        [_]f32{4.0},
+    };
+
+    var t1 = try Tensor(f32).fromArray(&allocator, &inputArrayA, &a_shape);
+    var t2 = try Tensor(f32).fromArray(&allocator, &inputArrayB, &b_shape);
+    var t3 = try Tensor(f32).fromArray(&allocator, &inputArrayB, &b_shape);
+
+    var result_tensor = try TensMath.gemm(f32, &t1, &t2, &t3, 1, 1, false, false);
+
+    try std.testing.expect(10.0 == result_tensor.data[0]);
+    try std.testing.expect(28.0 == result_tensor.data[1]);
+
+    result_tensor.deinit();
+    t1.deinit();
+    t2.deinit();
+    t3.deinit();
+}
+
+test "Gemm Y = a A*B + bC with broadcasting" {
+    std.debug.print("\n     test: Gemm Y = a A*B + bC with broadcasting", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var a_shape: [4]usize = [_]usize{ 1, 1, 3, 3 }; // 1 batch, 1 channel, 3x3 matrix
+    var b_shape: [4]usize = [_]usize{ 1, 1, 3, 2 }; // 1 batch, 1 channel, 3x2 matrix
+    var c_shape: [4]usize = [_]usize{ 1, 1, 1, 2 }; // 1 batch, 1 channel, 1x2 matrix
+
+    var inputArrayA: [3][3]f32 = [_][3]f32{
+        [_]f32{ 1.0, 2.0, 3.0 },
+        [_]f32{ 4.0, 5.0, 6.0 },
+        [_]f32{ 7.0, 8.0, 9.0 },
+    };
+    var inputArrayB: [3][2]f32 = [_][2]f32{
+        [_]f32{ 1.0, 2.0 },
+        [_]f32{ 4.0, 5.0 },
+        [_]f32{ 7.0, 8.0 },
+    };
+    var inputArrayC: [1][2]f32 = [_][2]f32{
+        [_]f32{ 1.0, 2.0 },
+    };
+
+    var t1 = try Tensor(f32).fromArray(&allocator, &inputArrayA, &a_shape);
+    var t2 = try Tensor(f32).fromArray(&allocator, &inputArrayB, &b_shape);
+    var t3 = try Tensor(f32).fromArray(&allocator, &inputArrayC, &c_shape);
+
+    var result_tensor = try TensMath.gemm(f32, &t1, &t2, &t3, 1, 1, false, false);
+
+    try std.testing.expect(31.0 == result_tensor.data[0]);
+    try std.testing.expect(128.0 == result_tensor.data[5]);
+
+    result_tensor.deinit();
+    t1.deinit();
+    t2.deinit();
+    t3.deinit();
+}
+
+test "Gemm Y = a A*B + bC with broadcasting, custom parameters v1" {
+    std.debug.print("\n     test: Gemm Y = a A*B + bC with broadcasting, custom parameters v1", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var a_shape: [4]usize = [_]usize{ 1, 1, 3, 3 }; // 1 batch, 1 channel, 3x3 matrix
+    var b_shape: [4]usize = [_]usize{ 1, 1, 2, 3 }; // 1 batch, 1 channel, 2x3 matrix
+    var c_shape: [4]usize = [_]usize{ 1, 1, 1, 2 }; // 1 batch, 1 channel, 1x2 matrix
+
+    var inputArrayA: [3][3]f32 = [_][3]f32{
+        [_]f32{ 1.0, 2.0, 3.0 },
+        [_]f32{ 4.0, 5.0, 6.0 },
+        [_]f32{ 7.0, 8.0, 9.0 },
+    };
+    var inputArrayB: [2][3]f32 = [_][3]f32{
+        [_]f32{ 1.0, 4.0, 7.0 },
+        [_]f32{ 2.0, 5.0, 8.0 },
+    };
+    var inputArrayC: [1][2]f32 = [_][2]f32{
+        [_]f32{ 1.0, 2.0 },
+    };
+
+    var t1 = try Tensor(f32).fromArray(&allocator, &inputArrayA, &a_shape);
+    var t2 = try Tensor(f32).fromArray(&allocator, &inputArrayB, &b_shape);
+    var t3 = try Tensor(f32).fromArray(&allocator, &inputArrayC, &c_shape);
+
+    var result_tensor = try TensMath.gemm(f32, &t1, &t2, &t3, 2, 3, false, true);
+
+    try std.testing.expect(63.0 == result_tensor.data[0]);
+    try std.testing.expect(258.0 == result_tensor.data[5]);
+
+    result_tensor.deinit();
+    t1.deinit();
+    t2.deinit();
+    t3.deinit();
+}
+
+test "Gemm Y = a A*B + bC with broadcasting, custom parameters v2" {
+    std.debug.print("\n     test: Gemm Y = a A*B + bC with broadcasting, custom parameters v2", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var a_shape: [4]usize = [_]usize{ 1, 1, 3, 2 }; // 1 batch, 1 channel, 3x3 matrix
+    var b_shape: [4]usize = [_]usize{ 1, 1, 2, 3 }; // 1 batch, 1 channel, 2x3 matrix
+    var c_shape: [4]usize = [_]usize{ 1, 1, 2, 1 }; // 1 batch, 1 channel, 1x2 matrix
+
+    var inputArrayA: [3][2]f32 = [_][2]f32{
+        [_]f32{
+            1.0,
+            2.0,
+        },
+        [_]f32{
+            4.0,
+            5.0,
+        },
+        [_]f32{
+            7.0,
+            8.0,
+        },
+    };
+    var inputArrayB: [2][3]f32 = [_][3]f32{
+        [_]f32{ 1.0, 4.0, 7.0 },
+        [_]f32{ 2.0, 5.0, 8.0 },
+    };
+    var inputArrayC: [2][1]f32 = [_][1]f32{
+        [_]f32{1.0},
+        [_]f32{2.0},
+    };
+
+    var t1 = try Tensor(f32).fromArray(&allocator, &inputArrayA, &a_shape);
+    var t2 = try Tensor(f32).fromArray(&allocator, &inputArrayB, &b_shape);
+    var t3 = try Tensor(f32).fromArray(&allocator, &inputArrayC, &c_shape);
+
+    var result_tensor = try TensMath.gemm(f32, &t1, &t2, &t3, 2, 3, true, true);
+
+    try std.testing.expect(135.0 == result_tensor.data[0]);
+    try std.testing.expect(159.0 == result_tensor.data[1]);
+    try std.testing.expect(162.0 == result_tensor.data[2]);
+    try std.testing.expect(192.0 == result_tensor.data[3]);
+
+    result_tensor.deinit();
+    t1.deinit();
+    t2.deinit();
+    t3.deinit();
+}
+
+// this test is not passed as now, I think changes in dot_product are needed
+// test "Gemm Y = a A*B + bC with broadcasting, custom parameters, multiple batch/channels" {
+//     std.debug.print("\n     test: Gemm Y = a A*B + bC with broadcasting, custom parameters, multiple batch/channels", .{});
+
+//     const allocator = pkgAllocator.allocator;
+
+//     var a_shape: [4]usize = [_]usize{ 2, 2, 3, 2 }; // 2 batch, 2 channel, 3x2 matrix
+//     var b_shape: [4]usize = [_]usize{ 2, 2, 2, 3 }; // 2 batch, 2 channel, 2x3 matrix
+//     var c_shape: [4]usize = [_]usize{ 2, 2, 2, 1 }; // 2 batch, 2 channel, 2x1 matrix
+
+//     // 2 batch, 2 channel, 3x2 matrix
+//     var inputArrayA: [2][2][3][2]f32 = [_][2][3][2]f32{
+//         // Batch 0
+//         [_][3][2]f32{
+//             // Channel 0
+//             [_][2]f32{ [_]f32{ 1.0, 2.0 }, [_]f32{ 3.0, 4.0 }, [_]f32{ 5.0, 6.0 } },
+//             // Channel 1
+//             [_][2]f32{ [_]f32{ 7.0, 8.0 }, [_]f32{ 9.0, 10.0 }, [_]f32{ 11.0, 12.0 } },
+//         },
+//         // Batch 1
+//         [_][3][2]f32{
+//             // Channel 0
+//             [_][2]f32{ [_]f32{ 13.0, 14.0 }, [_]f32{ 15.0, 16.0 }, [_]f32{ 17.0, 18.0 } },
+//             // Channel 1
+//             [_][2]f32{ [_]f32{ 19.0, 20.0 }, [_]f32{ 21.0, 22.0 }, [_]f32{ 23.0, 24.0 } },
+//         },
+//     };
+
+//     // 2 batch, 2 channel, 2x3 matrix
+//     var inputArrayB: [2][2][2][3]f32 = [_][2][2][3]f32{
+//         // Batch 0
+//         [_][2][3]f32{
+//             // Channel 0
+//             [_][3]f32{ [_]f32{ 1.0, 2.0, 3.0 }, [_]f32{ 4.0, 5.0, 6.0 } },
+//             // Channel 1
+//             [_][3]f32{ [_]f32{ 7.0, 8.0, 9.0 }, [_]f32{ 10.0, 11.0, 12.0 } },
+//         },
+//         // Batch 1
+//         [_][2][3]f32{
+//             // Channel 0
+//             [_][3]f32{ [_]f32{ 13.0, 14.0, 15.0 }, [_]f32{ 16.0, 17.0, 18.0 } },
+//             // Channel 1
+//             [_][3]f32{ [_]f32{ 19.0, 20.0, 21.0 }, [_]f32{ 22.0, 23.0, 24.0 } },
+//         },
+//     };
+
+//     // 2 batch, 2 channel, 2x1 matrix
+//     var inputArrayC: [2][2][2][1]f32 = [_][2][2][1]f32{
+//         // Batch 0
+//         [_][2][1]f32{
+//             // Channel 0
+//             [_][1]f32{ [_]f32{1.0}, [_]f32{2.0} },
+//             // Channel 1
+//             [_][1]f32{ [_]f32{3.0}, [_]f32{4.0} },
+//         },
+//         // Batch 1
+//         [_][2][1]f32{
+//             // Channel 0
+//             [_][1]f32{ [_]f32{5.0}, [_]f32{6.0} },
+//             // Channel 1
+//             [_][1]f32{ [_]f32{7.0}, [_]f32{8.0} },
+//         },
+//     };
+
+//     var t1 = try Tensor(f32).fromArray(&allocator, &inputArrayA, &a_shape);
+//     var t2 = try Tensor(f32).fromArray(&allocator, &inputArrayB, &b_shape);
+//     var t3 = try Tensor(f32).fromArray(&allocator, &inputArrayC, &c_shape);
+
+//     var result_tensor = try TensMath.gemm(f32, &t1, &t2, &t3, 2, 3, true, true);
+
+// debug
+//     for (0..result_tensor.data.len) |i|
+//         std.debug.print("\nres[{d}] {d}", .{ i, result_tensor.data[i] });
+
+//     try std.testing.expect(2549.0 == result_tensor.data[12]);
+//     try std.testing.expect(2927.0 == result_tensor.data[13]);
+//     try std.testing.expect(2672.0 == result_tensor.data[14]);
+//     try std.testing.expect(3068.0 == result_tensor.data[15]);
+
+//     result_tensor.deinit();
+//     t1.deinit();
+//     t2.deinit();
+//     t3.deinit();
+// }
+
+test "Error when input tensors aren't 4D" {
+    std.debug.print("\n     test: Error when input tensors aren't 4D", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape1: [3]usize = [_]usize{ 1.0, 2.0, 2.0 }; // missing batch, 1 batch, 2x2 matrix
+    var shape2: [3]usize = [_]usize{ 1.0, 2.0, 2.0 }; // missing batch, 1 batch, 2x2 matrix
+    var t1 = try Tensor(f32).fromShape(&allocator, &shape1);
+    var t2 = try Tensor(f32).fromShape(&allocator, &shape2);
+
+    try std.testing.expectError(TensorMathError.InputTensorsWrongShape, TensMath.gemm(f32, &t1, &t2, null, 1, 1, false, false));
+
+    _ = TensMath.gemm(f32, &t1, &t2, null, 1, 1, false, false) catch |err| {
+        std.debug.print("\n _______ {s} ______", .{ErrorHandler.errorDetails(err)});
+    };
+    t1.deinit();
+    t2.deinit();
+}
+
+test "Error when there's a mismatch in batch or channel dimension" {
+    std.debug.print("\n     test: Error when there's a mismatch in batch or channel dimension", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape1: [4]usize = [_]usize{ 2.0, 1.0, 2.0, 2.0 }; // batch/channel mismatch, 2x2 matrix
+    var shape2: [4]usize = [_]usize{ 1.0, 2.0, 2.0, 2.0 }; // batch/channel mismatch, 2x2 matrix
+    var t1 = try Tensor(f32).fromShape(&allocator, &shape1);
+    var t2 = try Tensor(f32).fromShape(&allocator, &shape2);
+
+    try std.testing.expectError(TensorMathError.InputTensorDifferentShape, TensMath.gemm(f32, &t1, &t2, null, 1, 1, false, false));
+
+    _ = TensMath.gemm(f32, &t1, &t2, null, 1, 1, false, false) catch |err| {
+        std.debug.print("\n _______ {s} ______", .{ErrorHandler.errorDetails(err)});
+    };
+    t1.deinit();
+    t2.deinit();
+}
+
+test "Error when input tensors have incompatible sizes for gemm" {
+    std.debug.print("\n     test: Error when input tensors have incompatible sizes for gemm", .{});
+
+    const allocator = pkgAllocator.allocator;
+
+    var shape1: [4]usize = [_]usize{ 4, 4, 2, 2 }; // 1 batch, 1 channel, 2x2 matrix, not compatible for product
+    var shape2: [4]usize = [_]usize{ 4, 4, 3, 2 }; // 1 batch, 1 channel, 3x2 matrix, not compatible for product
+    var t1 = try Tensor(f32).fromShape(&allocator, &shape1);
+    var t2 = try Tensor(f32).fromShape(&allocator, &shape2);
+
+    try std.testing.expectError(TensorMathError.InputTensorDimensionMismatch, TensMath.gemm(f32, &t1, &t2, null, 1, 1, false, false));
+
+    _ = TensMath.gemm(f32, &t1, &t2, null, 1, 1, false, false) catch |err| {
+        std.debug.print("\n _______ {s} ______", .{ErrorHandler.errorDetails(err)});
+    };
+    t1.deinit();
+    t2.deinit();
+}

--- a/tests/Core/Tensor/TensorMath/test_tensor_math.zig
+++ b/tests/Core/Tensor/TensorMath/test_tensor_math.zig
@@ -12,4 +12,5 @@ test {
     _ = @import("test_op_convolution.zig");
     _ = @import("test_op_dot_product.zig");
     _ = @import("test_op_pooling.zig");
+    _ = @import("test_op_gemm.zig");
 }


### PR DESCRIPTION

# Pull Request Template

## Description

gemm pretty finished + test, op_dot_product divided in lean and standard but not onnx compliant, transposeLastTwo funct

**Related Issue:** Closes #issue_number

## Type of Change

Please mark the options that are relevant:

- [ ] Bug fix 🐛
- [X] New feature 🚀
- [ ] Documentation update 📚
- [ ] Other (please describe):

## Checklist

- [X] My code follows the project's coding style guidelines.
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding updates to the documentation.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests pass.

## Testing

Pass all tests + new test except a new particular test for gemm with multiple batch/channels (commented out for now)

## Screenshots (if applicable)

If applicable, add screenshots to help explain your changes.

## Additional Information

Add any other context or information about the pull request here.
